### PR TITLE
Allow reading from yaml config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 authors = ["anxiousmodernman", "jeffmay"]
 
 [dependencies]
+rustfmt = "0.5.0"
+yaml-rust = "*"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
 # coded
 Code activity monitor
+
+## Rust language notes
+
+_We're still learning Rust. Leave your learnings here._
+
+### Put ~/.cargo/bin on your PATH
+
+Rust tools installed via `cargo install` need to be available. Ex: `cargo-fmt`
+
+### The `tests` dir is for integration tests
+
+Cargo compiles all tests in */tests* as a separate crate. This guarantees
+that they're integration tests, because they _must_ declare
+
+```rust
+extern crate coded;
+use coded::helpers;
+```
+----
+
+### println!(...) doesn't work in tests
+
+The test runner captures stdout. Disable this behavior like
+
+```
+cargo test -- --nocapture
+```
+
+----
+
+### Lambdas
+
+```rust
+let f = |x: Vec<i32>| -> Vec<i32> {
+  println!(x);
+  x   // return x
+}
+```
+
+---- 
+
+### Shell Aliases
+
+`cb="cargo build"` and `alias ct="cargo test -- --nocapture"`
+
+----
+
+### Get help in chat
+
+Chill with others learning rust in IRC
+
+Web client that looks decent: https://kiwiirc.com/client
+Network: irc.mozilla.org
+Channel: #rust-beginners
+
+

--- a/example.yml
+++ b/example.yml
@@ -1,0 +1,2 @@
+fuck:
+  yoo: "asshole"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,0 +1,7 @@
+extern crate yaml_rust;
+
+
+
+fn main() {
+
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,45 @@
+extern crate yaml_rust;
+
+use std::fs::File;
+use std::io;
+
+use std::io::prelude::*;
+use std::process; 
+
+use self::yaml_rust::{YamlLoader};
+
+#[derive(Debug)]
+pub struct Config {
+    // dirs content is String so Config owns its string data
+    pub dirs: Vec<String>,
+}
+
+pub fn read_file(filename: &str) -> Result<String, io::Error> {
+    let mut f = try!(File::open(filename));
+    let mut s = String::new();
+    try!(f.read_to_string(&mut s));
+    Ok(s)
+}
+
+pub fn new_config(path: &str) -> Config {  
+    match read_file(path) {
+        Ok(s) => {
+            let parsed = YamlLoader::load_from_str(&s).unwrap();
+            let dirs = parsed[0]["dirs"].as_vec().unwrap(); 
+            let mut v1 = Vec::new();
+            for item in dirs {
+                match item.as_str() {
+                    Some(x) => v1.push(x.to_string()),
+                    _ => ()
+                }
+            }
+            let conf = Config{dirs: v1};
+            return conf;
+        }
+        Err(error) => {
+            println!("{:?}", error);
+            process::exit(1);  
+        }
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,1 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-    }
-}
+pub mod helpers;

--- a/tests/conf.yml
+++ b/tests/conf.yml
@@ -1,0 +1,5 @@
+dirs:
+    - "~/Code"
+    - "/baz/foo"
+
+

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -1,0 +1,22 @@
+extern crate coded;
+
+use coded::helpers;
+
+/*
+ * NOTE: stdout is captured by cargo, so println! does not print to console
+ * automatically. To see println! output, run the tests with these flags:
+ *
+ *     $ cargo test -- --nocapture
+ *
+ * See: http://stackoverflow.com/questions/25106554/println-doesnt-work-in-rust-unit-tests
+ */
+
+
+#[test]
+fn new_config_read() {
+    let conf: helpers::Config = helpers::new_config("tests/conf.yml");
+    println!("CONF DEBUG: {:?}", conf);
+    assert_eq!(conf.dirs.len(), 2);
+    assert_eq!(conf.dirs[0].as_str(), "~/Code");
+}
+


### PR DESCRIPTION
Use String instead of "string slice" &str in Config struct
Why? String is heap-allocated, so using this

``` rust
pub struct Config {
   dirs: Vec<String>
}
```

... lets us avoid lifetime headaches.

Also moved main.rs to /bin subdirectory. This is a cargo convention that
aids the rust compiler. Similarly, modules intended for export need to
be listed in lib.rs

Note that all tests that run under /tests are compiled as a separate
crate, and should be thought of as integration tests. Unit tests can be
defined in library files themselves.
